### PR TITLE
Fix potentially uninitialized local pointer variable

### DIFF
--- a/examples/img2avi.c
+++ b/examples/img2avi.c
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
   int first;
   int width;
   int height;
-  s_movie * movie;
+  s_movie * movie = NULL;
   s_params * params;
   s_image *image;
   char formatbuf[20];

--- a/mpeg2enc/putvlc.c
+++ b/mpeg2enc/putvlc.c
@@ -103,7 +103,7 @@ void
 simpeg_encode_putAC(simpeg_encode_context * context,int run, int signed_level, int vlcformat)
 {
   int level, len;
-  VLCtable *ptab;
+  VLCtable *ptab = NULL;
 
   level = (signed_level<0) ? -signed_level : signed_level; /* abs(signed_level) */
 


### PR DESCRIPTION
Fix [C4703](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4703) compiler errors when compiling on UWP due to potentially uninitialized local pointer variable.