### PR TITLE
Shorten PROJECT_BRIEF in simage.doxygen.awesome.cmake.in to avoid overlap of search box

### DIFF
--- a/docs/simage.doxygen.awesome.cmake.in
+++ b/docs/simage.doxygen.awesome.cmake.in
@@ -6,7 +6,7 @@
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = @PROJECT_NAME@
 PROJECT_NUMBER         = @PROJECT_VERSION@
-PROJECT_BRIEF          = "A library with image format loaders and front-ends to common import libraries"
+PROJECT_BRIEF          = "Coin3D texture image library"
 PROJECT_LOGO           = @CMAKE_SOURCE_DIR@/docs/doxygen/Coin_logo.png
 PROJECT_ICON           =
 OUTPUT_DIRECTORY       =


### PR DESCRIPTION
Here you can see the reason for this fix:

![2024-05-16_14h46_24](https://github.com/coin3d/simage/assets/4239304/c2d1b0ac-c26e-44cc-b179-c741d803b8f6)
