### PR TITLE
Fix CMake compatibility: update minimum version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0...3.29)
+cmake_minimum_required(VERSION 3.5...3.29)
 
 set(SIMAGE_MAJOR_VERSION 1)
 set(SIMAGE_MINOR_VERSION 8)

--- a/giflib/quantize.c
+++ b/giflib/quantize.c
@@ -61,9 +61,9 @@ int
 GifQuantizeBuffer(unsigned int Width,
                unsigned int Height,
                int *ColorMapSize,
-               GifByteType * RedInput,
-               GifByteType * GreenInput,
-               GifByteType * BlueInput,
+               const GifByteType * RedInput,
+               const GifByteType * GreenInput,
+               const GifByteType * BlueInput,
                GifByteType * OutputBuffer,
                GifColorType * OutputColorMap) {
 

--- a/giflib/quantize.h
+++ b/giflib/quantize.h
@@ -15,8 +15,8 @@ SPDX-License-Identifier: MIT
  Color table quantization
 ******************************************************************************/
 int GifQuantizeBuffer(unsigned int Width, unsigned int Height,
-                   int *ColorMapSize, GifByteType * RedInput,
-                   GifByteType * GreenInput, GifByteType * BlueInput,
+                   int *ColorMapSize, const GifByteType * RedInput,
+                   const GifByteType * GreenInput, const GifByteType * BlueInput,
                    GifByteType * OutputBuffer,
                    GifColorType * OutputColorMap);
 


### PR DESCRIPTION
Newer version of CMake no longer supports versions < 3.5. Update cmake_minimum_required from 3.0 to 3.5 to resolve build errors.